### PR TITLE
Added config to disable html escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -1124,9 +1124,11 @@ var XBBCODE = (function() {
     ret.html = ret.html.replace("&#91;", "["); // put ['s back in
     ret.html = ret.html.replace("&#93;", "]"); // put ['s back in
 
-    ret.html = ret.html.replace(/&lt;/g, "<"); // unescape HTML tag brackets
-    ret.html = ret.html.replace(/&gt;/g, ">"); // unescape HTML tag brackets
-
+    if (!config.escapeHtml) {
+      ret.html = ret.html.replace(/&lt;/g, "<"); // unescape HTML tag brackets
+      ret.html = ret.html.replace(/&gt;/g, ">"); // unescape HTML tag brackets
+    }
+    
     ret.error = (errQueue.length === 0) ? false : true;
     ret.errorQueue = errQueue;
 


### PR DESCRIPTION
This patch makes it possible to use:

``` js
var ret = parser.process({
  "escapeHtml": true,
  "text": "I have some <iframe src='http://google.de'></iframe> for [b]you[/b]"
})
// ret.html: "I have some &lt;iframe src='http://google.de'&gt;&lt;/iframe&gt; for <b>you</b>"
```

or

``` js
var ret = parser.process({
  "escapeHtml": false,
  "text": "I have some <iframe src='http://google.de'></iframe> for [b]you[/b]"
})
// ret.html: "I have some <iframe src='http://google.de'></iframe> for <b>you</b>"
```

where `escapeHtml` is by default `false` to stay backwards compatible.
